### PR TITLE
Fix build failure on go version 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 		 --always --dirty --abbrev=8)
 BUILD_TGT := soda-controller-$(VERSION)-linux-amd64
 
+export GO111MODULE=on
+
 all: build
 
 ubuntu-dev-setup:


### PR DESCRIPTION
This PR fixes issue #20
The default value of GO111MODULE is different in go versions (GO111MODULE=auto in go 1.12, but GO111MODULE=on in go 1.13)
https://blog.golang.org/modules2019

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
> /kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
![Screenshot from 2020-06-13 09-18-39](https://user-images.githubusercontent.com/22949848/84559298-096b2c00-ad57-11ea-9c21-18fcdf0ddc37.png)
